### PR TITLE
Using '/usr/bin/env python' to execute python with the current environment.

### DIFF
--- a/bin/baboon
+++ b/bin/baboon
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys


### PR DESCRIPTION
When we are in a virtual environment, it is necessary to use 'env' to avoid having to call the Python interpreter of that environment.
